### PR TITLE
added support to update the refresh_token with the one returned from …

### DIFF
--- a/lib/refresh.js
+++ b/lib/refresh.js
@@ -42,7 +42,8 @@ function TokenProvider (url, options) {
     this.currentToken = {
       access_token:    this.options.access_token,
       expires_in:      this.options.expires_in,
-      expires_in_date: this.options.expires_in_date
+      expires_in_date: this.options.expires_in_date,
+      refresh_token:   this.options.refresh_token
     };
   }
 
@@ -63,7 +64,7 @@ TokenProvider.prototype = Object.create(EventEmitter.prototype);
  */
 TokenProvider.prototype.getToken = function (done) {
   if(this.currentToken && this.currentToken.expires_in_date > new Date()){
-    return done(null, this.currentToken.access_token);
+      return done(null, this.currentToken.access_token, this.currentToken.refresh_token);
   }
 
   request.post({
@@ -91,13 +92,15 @@ TokenProvider.prototype.getToken = function (done) {
     }
 
     this.currentToken = JSON.parse(body);
-
+    if (this.currentToken.refresh_token) {
+	this.options.refresh_token = this.currentToken.refresh_token;
+    }
     this.currentToken.expires_in_date =
       new Date((new Date()).getTime() +  this.currentToken.expires_in * 1000);
 
     this.emit('new token', this.currentToken);
 
-    return done(null, this.currentToken.access_token);
+    return done(null, this.currentToken.access_token, this.options.refresh_token);
 
   }.bind(this));
 };


### PR DESCRIPTION
…the token endpoint.  So that next call will use the new refresh_token as the old one has expired.